### PR TITLE
Initialize project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# CRI-O MCP Server
+
+This project provides a minimal skeleton for building a Machine Config Pool (MCP) server for CRI-O deployments.
+
+## Structure
+- `cmd/mcp-server`: entry point for running the server
+- `pkg/api`: APIs exposed by the server
+- `pkg/cri`: utilities for interacting with the CRI implementation
+
+## Getting Started
+Initialize dependencies and build the binary:
+
+```bash
+go build ./cmd/mcp-server
+```
+
+This repository currently contains placeholder packages and is ready for further development.

--- a/cmd/mcp-server/main.go
+++ b/cmd/mcp-server/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("mcp-server is under construction")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/harche/crio-mcp-server
+
+go 1.23.8

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,0 +1,3 @@
+package api
+
+// Placeholder package for future API implementations.

--- a/pkg/cri/cri.go
+++ b/pkg/cri/cri.go
@@ -1,0 +1,3 @@
+package cri
+
+// Placeholder package for CRI interactions.


### PR DESCRIPTION
## Summary
- set up module `github.com/harche/crio-mcp-server`
- add placeholder main binary under `cmd/mcp-server`
- create `pkg/api` and `pkg/cri` packages
- provide a minimal README

## Testing
- `go build ./cmd/mcp-server`
- `./mcp-server`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_684c443cefa0832f98a0909667322316