### PR TITLE
Add container config retrieval RPC

### DIFF
--- a/pkg/cri/container.go
+++ b/pkg/cri/container.go
@@ -1,0 +1,36 @@
+package cri
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ReadContainerConfig attempts to read the container's config.json from
+// well-known CRI-O overlay storage locations.
+func ReadContainerConfig(id string) (string, error) {
+	cleanID := filepath.Base(id)
+	if cleanID != id {
+		return "", fmt.Errorf("invalid container id")
+	}
+
+	dirs := []string{
+		"/run/containers/storage",
+		"/var/lib/containers/storage",
+	}
+	if runtimeDir := os.Getenv("XDG_RUNTIME_DIR"); runtimeDir != "" {
+		dirs = append([]string{filepath.Join(runtimeDir, "containers/storage")}, dirs...)
+	}
+
+	for _, base := range dirs {
+		path := filepath.Join(base, "overlay-containers", cleanID, "userdata", "config.json")
+		data, err := os.ReadFile(path)
+		if err == nil {
+			return string(data), nil
+		}
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+	}
+	return "", fmt.Errorf("container config not found")
+}

--- a/pkg/proto/mcp.pb.go
+++ b/pkg/proto/mcp.pb.go
@@ -329,6 +329,50 @@ func (x *ContainerStatsResponse) GetMemoryUsageBytes() uint64 {
 	return 0
 }
 
+type ContainerConfigResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Config        string                 `protobuf:"bytes,1,opt,name=config,proto3" json:"config,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ContainerConfigResponse) Reset() {
+	*x = ContainerConfigResponse{}
+	mi := &file_proto_mcp_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ContainerConfigResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ContainerConfigResponse) ProtoMessage() {}
+
+func (x *ContainerConfigResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_mcp_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ContainerConfigResponse.ProtoReflect.Descriptor instead.
+func (*ContainerConfigResponse) Descriptor() ([]byte, []int) {
+	return file_proto_mcp_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *ContainerConfigResponse) GetConfig() string {
+	if x != nil {
+		return x.Config
+	}
+	return ""
+}
+
 var File_proto_mcp_proto protoreflect.FileDescriptor
 
 const file_proto_mcp_proto_rawDesc = "" +
@@ -349,7 +393,9 @@ const file_proto_mcp_proto_rawDesc = "" +
 	"\x04info\x18\x01 \x01(\tR\x04info\"l\n" +
 	"\x16ContainerStatsResponse\x12$\n" +
 	"\x0ecpu_usage_usec\x18\x01 \x01(\x04R\fcpuUsageUsec\x12,\n" +
-	"\x12memory_usage_bytes\x18\x02 \x01(\x04R\x10memoryUsageBytes2\xc8\x02\n" +
+	"\x12memory_usage_bytes\x18\x02 \x01(\x04R\x10memoryUsageBytes\"1\n" +
+	"\x17ContainerConfigResponse\x12\x16\n" +
+	"\x06config\x18\x01 \x01(\tR\x06config2\x93\x03\n" +
 	"\n" +
 	"MCPService\x124\n" +
 	"\rGetCrioConfig\x12\n" +
@@ -359,7 +405,8 @@ const file_proto_mcp_proto_rawDesc = "" +
 	"\x0eListContainers\x12\n" +
 	".mcp.Empty\x1a\x17.mcp.ContainersResponse\x12H\n" +
 	"\x10InspectContainer\x12\x15.mcp.ContainerRequest\x1a\x1d.mcp.ContainerInspectResponse\x12G\n" +
-	"\x11GetContainerStats\x12\x15.mcp.ContainerRequest\x1a\x1b.mcp.ContainerStatsResponseB-Z+github.com/harche/crio-mcp-server/pkg/protob\x06proto3"
+	"\x11GetContainerStats\x12\x15.mcp.ContainerRequest\x1a\x1b.mcp.ContainerStatsResponse\x12I\n" +
+	"\x12GetContainerConfig\x12\x15.mcp.ContainerRequest\x1a\x1c.mcp.ContainerConfigResponseB-Z+github.com/harche/crio-mcp-server/pkg/protob\x06proto3"
 
 var (
 	file_proto_mcp_proto_rawDescOnce sync.Once
@@ -373,7 +420,7 @@ func file_proto_mcp_proto_rawDescGZIP() []byte {
 	return file_proto_mcp_proto_rawDescData
 }
 
-var file_proto_mcp_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_proto_mcp_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_proto_mcp_proto_goTypes = []any{
 	(*Empty)(nil),                    // 0: mcp.Empty
 	(*CrioConfigResponse)(nil),       // 1: mcp.CrioConfigResponse
@@ -382,6 +429,7 @@ var file_proto_mcp_proto_goTypes = []any{
 	(*ContainerRequest)(nil),         // 4: mcp.ContainerRequest
 	(*ContainerInspectResponse)(nil), // 5: mcp.ContainerInspectResponse
 	(*ContainerStatsResponse)(nil),   // 6: mcp.ContainerStatsResponse
+	(*ContainerConfigResponse)(nil),  // 7: mcp.ContainerConfigResponse
 }
 var file_proto_mcp_proto_depIdxs = []int32{
 	0, // 0: mcp.MCPService.GetCrioConfig:input_type -> mcp.Empty
@@ -389,13 +437,15 @@ var file_proto_mcp_proto_depIdxs = []int32{
 	0, // 2: mcp.MCPService.ListContainers:input_type -> mcp.Empty
 	4, // 3: mcp.MCPService.InspectContainer:input_type -> mcp.ContainerRequest
 	4, // 4: mcp.MCPService.GetContainerStats:input_type -> mcp.ContainerRequest
-	1, // 5: mcp.MCPService.GetCrioConfig:output_type -> mcp.CrioConfigResponse
-	2, // 6: mcp.MCPService.GetRuntimeStatus:output_type -> mcp.RuntimeStatusResponse
-	3, // 7: mcp.MCPService.ListContainers:output_type -> mcp.ContainersResponse
-	5, // 8: mcp.MCPService.InspectContainer:output_type -> mcp.ContainerInspectResponse
-	6, // 9: mcp.MCPService.GetContainerStats:output_type -> mcp.ContainerStatsResponse
-	5, // [5:10] is the sub-list for method output_type
-	0, // [0:5] is the sub-list for method input_type
+	4, // 5: mcp.MCPService.GetContainerConfig:input_type -> mcp.ContainerRequest
+	1, // 6: mcp.MCPService.GetCrioConfig:output_type -> mcp.CrioConfigResponse
+	2, // 7: mcp.MCPService.GetRuntimeStatus:output_type -> mcp.RuntimeStatusResponse
+	3, // 8: mcp.MCPService.ListContainers:output_type -> mcp.ContainersResponse
+	5, // 9: mcp.MCPService.InspectContainer:output_type -> mcp.ContainerInspectResponse
+	6, // 10: mcp.MCPService.GetContainerStats:output_type -> mcp.ContainerStatsResponse
+	7, // 11: mcp.MCPService.GetContainerConfig:output_type -> mcp.ContainerConfigResponse
+	6, // [6:12] is the sub-list for method output_type
+	0, // [0:6] is the sub-list for method input_type
 	0, // [0:0] is the sub-list for extension type_name
 	0, // [0:0] is the sub-list for extension extendee
 	0, // [0:0] is the sub-list for field type_name
@@ -412,7 +462,7 @@ func file_proto_mcp_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_mcp_proto_rawDesc), len(file_proto_mcp_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   7,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/proto/mcp_grpc.pb.go
+++ b/pkg/proto/mcp_grpc.pb.go
@@ -19,11 +19,12 @@ import (
 const _ = grpc.SupportPackageIsVersion7
 
 const (
-	MCPService_GetCrioConfig_FullMethodName     = "/mcp.MCPService/GetCrioConfig"
-	MCPService_GetRuntimeStatus_FullMethodName  = "/mcp.MCPService/GetRuntimeStatus"
-	MCPService_ListContainers_FullMethodName    = "/mcp.MCPService/ListContainers"
-	MCPService_InspectContainer_FullMethodName  = "/mcp.MCPService/InspectContainer"
-	MCPService_GetContainerStats_FullMethodName = "/mcp.MCPService/GetContainerStats"
+	MCPService_GetCrioConfig_FullMethodName      = "/mcp.MCPService/GetCrioConfig"
+	MCPService_GetRuntimeStatus_FullMethodName   = "/mcp.MCPService/GetRuntimeStatus"
+	MCPService_ListContainers_FullMethodName     = "/mcp.MCPService/ListContainers"
+	MCPService_InspectContainer_FullMethodName   = "/mcp.MCPService/InspectContainer"
+	MCPService_GetContainerStats_FullMethodName  = "/mcp.MCPService/GetContainerStats"
+	MCPService_GetContainerConfig_FullMethodName = "/mcp.MCPService/GetContainerConfig"
 )
 
 // MCPServiceClient is the client API for MCPService service.
@@ -35,6 +36,7 @@ type MCPServiceClient interface {
 	ListContainers(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*ContainersResponse, error)
 	InspectContainer(ctx context.Context, in *ContainerRequest, opts ...grpc.CallOption) (*ContainerInspectResponse, error)
 	GetContainerStats(ctx context.Context, in *ContainerRequest, opts ...grpc.CallOption) (*ContainerStatsResponse, error)
+	GetContainerConfig(ctx context.Context, in *ContainerRequest, opts ...grpc.CallOption) (*ContainerConfigResponse, error)
 }
 
 type mCPServiceClient struct {
@@ -90,6 +92,15 @@ func (c *mCPServiceClient) GetContainerStats(ctx context.Context, in *ContainerR
 	return out, nil
 }
 
+func (c *mCPServiceClient) GetContainerConfig(ctx context.Context, in *ContainerRequest, opts ...grpc.CallOption) (*ContainerConfigResponse, error) {
+	out := new(ContainerConfigResponse)
+	err := c.cc.Invoke(ctx, MCPService_GetContainerConfig_FullMethodName, in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // MCPServiceServer is the server API for MCPService service.
 // All implementations must embed UnimplementedMCPServiceServer
 // for forward compatibility
@@ -99,6 +110,7 @@ type MCPServiceServer interface {
 	ListContainers(context.Context, *Empty) (*ContainersResponse, error)
 	InspectContainer(context.Context, *ContainerRequest) (*ContainerInspectResponse, error)
 	GetContainerStats(context.Context, *ContainerRequest) (*ContainerStatsResponse, error)
+	GetContainerConfig(context.Context, *ContainerRequest) (*ContainerConfigResponse, error)
 	mustEmbedUnimplementedMCPServiceServer()
 }
 
@@ -120,6 +132,9 @@ func (UnimplementedMCPServiceServer) InspectContainer(context.Context, *Containe
 }
 func (UnimplementedMCPServiceServer) GetContainerStats(context.Context, *ContainerRequest) (*ContainerStatsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetContainerStats not implemented")
+}
+func (UnimplementedMCPServiceServer) GetContainerConfig(context.Context, *ContainerRequest) (*ContainerConfigResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetContainerConfig not implemented")
 }
 func (UnimplementedMCPServiceServer) mustEmbedUnimplementedMCPServiceServer() {}
 
@@ -224,6 +239,24 @@ func _MCPService_GetContainerStats_Handler(srv interface{}, ctx context.Context,
 	return interceptor(ctx, in, info, handler)
 }
 
+func _MCPService_GetContainerConfig_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ContainerRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MCPServiceServer).GetContainerConfig(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MCPService_GetContainerConfig_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MCPServiceServer).GetContainerConfig(ctx, req.(*ContainerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // MCPService_ServiceDesc is the grpc.ServiceDesc for MCPService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -250,6 +283,10 @@ var MCPService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetContainerStats",
 			Handler:    _MCPService_GetContainerStats_Handler,
+		},
+		{
+			MethodName: "GetContainerConfig",
+			Handler:    _MCPService_GetContainerConfig_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -79,6 +79,15 @@ func (s *MCPServer) GetContainerStats(ctx context.Context, req *pb.ContainerRequ
 	}, nil
 }
 
+func (s *MCPServer) GetContainerConfig(ctx context.Context, req *pb.ContainerRequest) (*pb.ContainerConfigResponse, error) {
+	cfg, err := cri.ReadContainerConfig(req.GetId())
+	if err != nil {
+		log.Printf("read container config error: %v", err)
+		return nil, status.Errorf(codes.Internal, "container config error")
+	}
+	return &pb.ContainerConfigResponse{Config: cfg}, nil
+}
+
 func (s *MCPServer) Start(addr string) error {
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {

--- a/proto/mcp.proto
+++ b/proto/mcp.proto
@@ -10,6 +10,7 @@ service MCPService {
   rpc ListContainers(Empty) returns (ContainersResponse);
   rpc InspectContainer(ContainerRequest) returns (ContainerInspectResponse);
   rpc GetContainerStats(ContainerRequest) returns (ContainerStatsResponse);
+  rpc GetContainerConfig(ContainerRequest) returns (ContainerConfigResponse);
 }
 
 message Empty {}
@@ -37,4 +38,8 @@ message ContainerInspectResponse {
 message ContainerStatsResponse {
   uint64 cpu_usage_usec = 1;
   uint64 memory_usage_bytes = 2;
+}
+
+message ContainerConfigResponse {
+  string config = 1;
 }


### PR DESCRIPTION
## Summary
- expose container config via new gRPC method
- provide helper to read CRI-O container config bundles

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684c4a9cecfc832f829f5ab5d08e8e9e