### PR TITLE
Update tooling instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,40 @@
 # CRI-O MCP Server
 
-This project provides a basic Model Context Protocol (MCP) server for CRI-O built using the [mcp-go](https://github.com/mark3labs/mcp-go) SDK. The goal is to expose CRI-O information to AI agents through the MCP interface.
+This repository contains a minimal [Model Context Protocol](https://github.com/mark3labs/mcp-go) (MCP) server that exposes CRI-O information through a set of command line tools.  The server is intended to be run from VS Code using the MCP extension and communicates over standard input/output.
 
-## Structure
-- `cmd/mcp-server`: entry point for running the server
-- `pkg/sdkserver`: MCP server scaffolding based on the SDK
-- `pkg/proto`: protobuf definitions from the original gRPC implementation
-- `pkg/server`: legacy gRPC server (will be replaced)
-- `pkg/api`: placeholder APIs
-- `pkg/cri`: utilities for interacting with the CRI implementation
+## Tools
 
-## Getting Started
-Initialize dependencies and build the binary:
+### `debug_node`
+Creates a temporary debug pod on a specified OpenShift node and runs arbitrary commands inside it.
 
-```bash
-go build ./cmd/mcp-server
-```
+Arguments:
 
-Run the server using the stdio transport:
+- `node_name` (string, required) – node to debug
+- `commands` (array of string) – commands executed in the pod (defaults to `journalctl --no-pager -u crio`)
+- `collect_files` (bool) – when true, files listed in `paths` are returned as resources
+- `paths` (array of string) – file or directory paths to copy from the host
 
-```bash
-./mcp-server --config /etc/crio/crio.conf
-```
+### `collect_node_logs`
+Streams systemd journal and container runtime logs from a node using `oc adm node-logs`.
 
-The current implementation only sets up the server scaffolding. Additional tools and resources will be added in future iterations.
+Arguments:
+
+- `node_name` (string, required) – target node
+- `since` (string) – RFC3339 timestamp or relative value accepted by `journalctl`
+- `compress` (bool) – if true, return logs as a gzip tarball instead of inline text
+
+## Running inside VS Code
+
+1. Open this repository in VS Code with the MCP extension enabled.
+2. Build the server:
+   ```bash
+   go build ./cmd/mcp-server
+   ```
+3. Start the binary from the integrated terminal:
+   ```bash
+   ./mcp-server
+   ```
+   Because it uses the stdio transport, the MCP extension will automatically attach.
+4. Use the command palette or MCP view to invoke `debug_node` or `collect_node_logs` and supply the required parameters.
+
+This implementation focuses solely on the MCP server and the tools above. The legacy gRPC server and old README have been removed.

--- a/cmd/mcp-server/main.go
+++ b/cmd/mcp-server/main.go
@@ -1,17 +1,13 @@
 package main
 
 import (
-	"flag"
 	"log"
 
 	"github.com/harche/crio-mcp-server/pkg/sdkserver"
 )
 
 func main() {
-	config := flag.String("config", "/etc/crio/crio.conf", "path to CRI-O config")
-	flag.Parse()
-
-	srv := sdkserver.New(*config)
+	srv := sdkserver.New()
 	if err := sdkserver.StartStdio(srv); err != nil {
 		log.Fatalf("server error: %v", err)
 	}

--- a/pkg/sdkserver/sdk.go
+++ b/pkg/sdkserver/sdk.go
@@ -5,9 +5,7 @@ import (
 )
 
 // New creates a new MCP server using the mcp-go SDK.
-// configPath is currently unused but will be wired into
-// tool and resource handlers in future implementations.
-func New(configPath string) *mcpserver.MCPServer {
+func New() *mcpserver.MCPServer {
 	srv := mcpserver.NewMCPServer(
 		"CRI-O MCP Server",
 		"0.1.0",
@@ -19,8 +17,6 @@ func New(configPath string) *mcpserver.MCPServer {
 		mcpserver.ServerTool{Tool: debugNodeTool, Handler: handleDebugNode},
 		mcpserver.ServerTool{Tool: nodeLogsTool, Handler: handleNodeLogs},
 	)
-
-	_ = configPath
 
 	return srv
 }


### PR DESCRIPTION
## Summary
- drop unused --config flag
- remove parameter from sdk server constructor
- simplify README instructions

## Testing
- `go test ./...`
- `go build ./cmd/mcp-server`


------
https://chatgpt.com/codex/tasks/task_e_684c6155df88832fb68d8bdd7492225c