### PR TITLE
Add must-gather and sosreport tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,18 @@ Runs `go tool pprof` with the supplied arguments to inspect CPU or memory profil
 Arguments:
 - `args` (array of string, required) – command-line arguments passed directly to `go tool pprof`
 
+### `collect_must_gather`
+Runs `oc adm must-gather` to capture cluster information. Create a temporary directory and pass it using `dest_dir` to keep all gathered data in one location. Explore `oc adm must-gather -h` for the full set of options.
+
+Arguments:
+- `dest_dir` (string) – local directory where the must-gather output is stored
+- `extra_args` (array of string) – additional flags forwarded to `oc adm must-gather`
+
 These helpers can be integrated into a custom MCP server or used directly with the `mcp-go` SDK.
+
+### `collect_sosreport`
+Runs `sosreport` inside a debug pod using toolbox. This captures detailed diagnostics from a node. Provide a Red Hat case ID if available.
+
+Arguments:
+- `node_name` (string, required) – node from which to gather the report
+- `case_id` (string) – optional support case identifier passed to `sosreport`

--- a/pkg/openshift/oc.go
+++ b/pkg/openshift/oc.go
@@ -32,3 +32,32 @@ func NodeLogs(nodeName, since string) (string, error) {
 	}
 	return string(out), nil
 }
+
+// MustGather runs `oc adm must-gather` with optional destination directory and
+// additional arguments.
+func MustGather(destDir string, extra []string) (string, error) {
+	args := []string{"adm", "must-gather"}
+	if destDir != "" {
+		args = append(args, fmt.Sprintf("--dest-dir=%s", destDir))
+	}
+	args = append(args, extra...)
+	out, err := run(args...)
+	if err != nil {
+		return "", fmt.Errorf("oc adm must-gather failed: %w: %s", err, out)
+	}
+	return string(out), nil
+}
+
+// SosReport collects a sosreport from the specified node using toolbox.
+// If caseID is non-empty, it is passed via --case-id.
+func SosReport(nodeName, caseID string) (string, error) {
+	args := []string{"debug", fmt.Sprintf("node/%s", nodeName), "--", "chroot", "/host", "toolbox", "--", "sosreport", "-k", "crio.all=on", "-k", "crio.logs=on", "--batch"}
+	if caseID != "" {
+		args = append(args, fmt.Sprintf("--case-id=%s", caseID))
+	}
+	out, err := run(args...)
+	if err != nil {
+		return "", fmt.Errorf("sosreport failed: %w: %s", err, out)
+	}
+	return string(out), nil
+}


### PR DESCRIPTION
## Summary
- add `collect_must_gather` tool
- add `collect_sosreport` tool to gather node diagnostics
- implement helper for running `sosreport` via `oc debug`
- document the new tools

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_684ca37baba4832f99ebb12c950a0e5e