### PR TITLE
Add helper to register all MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 This repository defines a couple of [Model Context Protocol](https://github.com/mark3labs/mcp-go) tools for debugging OpenShift nodes and collecting logs. The tools are implemented in `pkg/sdkserver/tools.go` and can be registered with any MCP server built using the `mcp-go` SDK.
 
+```go
+import (
+    "github.com/harche/crio-mcp-server/pkg/sdkserver"
+    "github.com/mark3labs/mcp-go/server"
+)
+
+s := server.NewMCPServer("demo", "1.0.0")
+sdkserver.RegisterTools(s)
+```
+
 ## Tools
 
 ### `debug_node`

--- a/pkg/sdkserver/tools.go
+++ b/pkg/sdkserver/tools.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/harche/crio-mcp-server/pkg/openshift"
 	mcp "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 )
 
 // debugNodeTool defines the debug_node MCP tool.
@@ -379,4 +380,22 @@ func handleNodeConfig(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallTo
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 	return mcp.NewToolResultText(out), nil
+}
+
+// RegisterTools registers all available tools with the provided server.
+func RegisterTools(s *server.MCPServer) {
+	s.AddTools(
+		server.ServerTool{Tool: debugNodeTool, Handler: handleDebugNode},
+		server.ServerTool{Tool: nodeLogsTool, Handler: handleNodeLogs},
+		server.ServerTool{Tool: pprofTool, Handler: handlePprof},
+		server.ServerTool{Tool: mustGatherTool, Handler: handleMustGather},
+		server.ServerTool{Tool: crictlTool, Handler: handleCrictl},
+		server.ServerTool{Tool: cgroupfsTool, Handler: handleTraverseCgroupfs},
+		server.ServerTool{Tool: sosReportTool, Handler: handleSosReport},
+		server.ServerTool{Tool: networkLogsTool, Handler: handleNetworkLogs},
+		server.ServerTool{Tool: profilingTool, Handler: handleProfilingNode},
+		server.ServerTool{Tool: eventsTool, Handler: handleEvents},
+		server.ServerTool{Tool: podLogsTool, Handler: handlePodLogs},
+		server.ServerTool{Tool: nodeConfigTool, Handler: handleNodeConfig},
+	)
 }


### PR DESCRIPTION
## Summary
- expose `RegisterTools` helper in the SDK server package
- document usage in the README

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684d5d752004832f8917e2d16b362dc4