### PR TITLE
Add tests and mockable runner

### DIFF
--- a/pkg/openshift/oc.go
+++ b/pkg/openshift/oc.go
@@ -7,14 +7,19 @@ import (
 )
 
 // run executes the oc command with given arguments and returns combined output.
-func run(args ...string) ([]byte, error) {
+//
+// It is defined as a variable to allow tests to substitute a fake implementation
+// without spawning external processes.
+// Run is used by helper functions to execute the oc command. Tests may override
+// this variable to avoid running external commands.
+var Run = func(args ...string) ([]byte, error) {
 	cmd := exec.Command("oc", args...)
 	return cmd.CombinedOutput()
 }
 
 // DebugNode runs `oc debug` for the given node and command.
 func DebugNode(nodeName, command string) (string, error) {
-	out, err := run("debug", fmt.Sprintf("node/%s", nodeName), "--", "chroot", "/host", "sh", "-c", command)
+	out, err := Run("debug", fmt.Sprintf("node/%s", nodeName), "--", "chroot", "/host", "sh", "-c", command)
 	if err != nil {
 		return "", fmt.Errorf("oc debug failed: %w: %s", err, out)
 	}
@@ -27,7 +32,7 @@ func NodeLogs(nodeName, since string) (string, error) {
 	if since != "" {
 		args = append(args, "--since", since)
 	}
-	out, err := run(args...)
+	out, err := Run(args...)
 	if err != nil {
 		return "", fmt.Errorf("oc adm node-logs failed: %w: %s", err, out)
 	}
@@ -42,7 +47,7 @@ func MustGather(destDir string, extra []string) (string, error) {
 		args = append(args, fmt.Sprintf("--dest-dir=%s", destDir))
 	}
 	args = append(args, extra...)
-	out, err := run(args...)
+	out, err := Run(args...)
 	if err != nil {
 		return "", fmt.Errorf("oc adm must-gather failed: %w: %s", err, out)
 	}
@@ -56,7 +61,7 @@ func SosReport(nodeName, caseID string) (string, error) {
 	if caseID != "" {
 		args = append(args, fmt.Sprintf("--case-id=%s", caseID))
 	}
-	out, err := run(args...)
+	out, err := Run(args...)
 	if err != nil {
 		return "", fmt.Errorf("sosreport failed: %w: %s", err, out)
 	}
@@ -78,7 +83,7 @@ func NetworkLogs(destDir string) (string, error) {
 		args = append(args, fmt.Sprintf("--dest-dir=%s", destDir))
 	}
 	args = append(args, "--", "/usr/bin/gather_network_logs")
-	out, err := run(args...)
+	out, err := Run(args...)
 	if err != nil {
 		return "", fmt.Errorf("gather_network_logs failed: %w: %s", err, out)
 	}
@@ -92,7 +97,7 @@ func ProfilingNode(destDir string) (string, error) {
 		args = append(args, fmt.Sprintf("--dest-dir=%s", destDir))
 	}
 	args = append(args, "--", "/usr/bin/gather_profiling_node")
-	out, err := run(args...)
+	out, err := Run(args...)
 	if err != nil {
 		return "", fmt.Errorf("gather_profiling_node failed: %w: %s", err, out)
 	}
@@ -101,7 +106,7 @@ func ProfilingNode(destDir string) (string, error) {
 
 // Events retrieves recent cluster events across all namespaces.
 func Events() (string, error) {
-	out, err := run("get", "events", "-A")
+	out, err := Run("get", "events", "-A")
 	if err != nil {
 		return "", fmt.Errorf("oc get events failed: %w: %s", err, out)
 	}
@@ -118,7 +123,7 @@ func PodLogs(namespace, pod, container, since string) (string, error) {
 	if since != "" {
 		args = append(args, "--since", since)
 	}
-	out, err := run(args...)
+	out, err := Run(args...)
 	if err != nil {
 		return "", fmt.Errorf("oc logs failed: %w: %s", err, out)
 	}

--- a/pkg/openshift/oc_test.go
+++ b/pkg/openshift/oc_test.go
@@ -1,0 +1,119 @@
+package openshift
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// helper to replace run during tests
+func withRunMock(f func(args ...string) ([]byte, error), test func()) {
+	orig := Run
+	Run = f
+	defer func() { Run = orig }()
+	test()
+}
+
+func TestNetworkLogs(t *testing.T) {
+	expected := []string{"adm", "must-gather", "--dest-dir=test", "--", "/usr/bin/gather_network_logs"}
+	withRunMock(func(args ...string) ([]byte, error) {
+		if fmt.Sprint(args) != fmt.Sprint(expected) {
+			t.Fatalf("unexpected args %v", args)
+		}
+		return []byte("logs"), nil
+	}, func() {
+		out, err := NetworkLogs("test")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out != "logs" {
+			t.Fatalf("unexpected output %q", out)
+		}
+	})
+}
+
+func TestNetworkLogsError(t *testing.T) {
+	withRunMock(func(args ...string) ([]byte, error) {
+		return []byte("bad"), errors.New("failure")
+	}, func() {
+		out, err := NetworkLogs("")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if out != "" {
+			t.Fatalf("expected empty output, got %q", out)
+		}
+	})
+}
+
+func TestProfilingNode(t *testing.T) {
+	expected := []string{"adm", "must-gather", "--dest-dir=/tmp", "--", "/usr/bin/gather_profiling_node"}
+	withRunMock(func(args ...string) ([]byte, error) {
+		if fmt.Sprint(args) != fmt.Sprint(expected) {
+			t.Fatalf("unexpected args %v", args)
+		}
+		return []byte("prof"), nil
+	}, func() {
+		out, err := ProfilingNode("/tmp")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out != "prof" {
+			t.Fatalf("unexpected output %q", out)
+		}
+	})
+}
+
+func TestEvents(t *testing.T) {
+	expected := []string{"get", "events", "-A"}
+	withRunMock(func(args ...string) ([]byte, error) {
+		if fmt.Sprint(args) != fmt.Sprint(expected) {
+			t.Fatalf("unexpected args %v", args)
+		}
+		return []byte("events"), nil
+	}, func() {
+		out, err := Events()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out != "events" {
+			t.Fatalf("unexpected output %q", out)
+		}
+	})
+}
+
+func TestPodLogs(t *testing.T) {
+	expected := []string{"logs", "-n", "ns", "pod", "-c", "ctr", "--since", "2h"}
+	withRunMock(func(args ...string) ([]byte, error) {
+		if fmt.Sprint(args) != fmt.Sprint(expected) {
+			t.Fatalf("unexpected args %v", args)
+		}
+		return []byte("pod logs"), nil
+	}, func() {
+		out, err := PodLogs("ns", "pod", "ctr", "2h")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out != "pod logs" {
+			t.Fatalf("unexpected output %q", out)
+		}
+	})
+}
+
+func TestNodeConfig(t *testing.T) {
+	expected := []string{"debug", "node/testnode", "--", "chroot", "/host", "sh", "-c", "cat /etc/kubernetes/kubelet.conf && echo --- && cat /etc/crio/crio.conf"}
+	withRunMock(func(args ...string) ([]byte, error) {
+		if fmt.Sprint(args) != fmt.Sprint(expected) {
+			t.Fatalf("unexpected args %v", args)
+		}
+		return []byte("cfg"), nil
+	}, func() {
+		out, err := NodeConfig("testnode")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out != "cfg" {
+			t.Fatalf("unexpected output %q", out)
+		}
+	})
+}

--- a/pkg/sdkserver/tools_test.go
+++ b/pkg/sdkserver/tools_test.go
@@ -1,0 +1,249 @@
+package sdkserver
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/harche/crio-mcp-server/pkg/openshift"
+	mcp "github.com/mark3labs/mcp-go/mcp"
+)
+
+func withRunMock(t *testing.T, expected []string, output string, err error, f func()) {
+	orig := openshift.Run
+	openshift.Run = func(args ...string) ([]byte, error) {
+		if fmt.Sprint(args) != fmt.Sprint(expected) {
+			t.Fatalf("unexpected args %v", args)
+		}
+		return []byte(output), err
+	}
+	defer func() { openshift.Run = orig }()
+	f()
+}
+
+func text(result *mcp.CallToolResult) string {
+	if len(result.Content) == 0 {
+		return ""
+	}
+	return result.Content[0].(mcp.TextContent).Text
+}
+
+func TestHandleDebugNode(t *testing.T) {
+	expectedArgs := []string{"debug", "node/test", "--", "chroot", "/host", "sh", "-c", "echo hi"}
+	withRunMock(t, expectedArgs, "hi", nil, func() {
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+			"node_name": "test",
+			"commands":  []any{"echo hi"},
+		}}}
+		res, err := handleDebugNode(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.IsError {
+			t.Fatalf("unexpected error result: %v", text(res))
+		}
+		if text(res) != "hi" {
+			t.Fatalf("unexpected result %q", text(res))
+		}
+	})
+}
+
+func TestHandleDebugNodeMissingArg(t *testing.T) {
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{}}}
+	res, err := handleDebugNode(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected error result")
+	}
+}
+
+func TestHandleNodeLogs(t *testing.T) {
+	args := []string{"adm", "node-logs", "node1", "--since", "1h"}
+	withRunMock(t, args, "logs", nil, func() {
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+			"node_name": "node1",
+			"since":     "1h",
+		}}}
+		res, err := handleNodeLogs(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.IsError || text(res) != "logs" {
+			t.Fatalf("unexpected result: %v", text(res))
+		}
+	})
+}
+
+func TestHandlePprofArgsRequired(t *testing.T) {
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{}}}
+	res, err := handlePprof(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected error result")
+	}
+}
+
+func TestHandlePprof(t *testing.T) {
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"args": []any{"-h"},
+	}}}
+	res, err := handlePprof(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error result: %v", text(res))
+	}
+	if text(res) == "" {
+		t.Fatalf("expected output")
+	}
+}
+
+func TestHandleMustGather(t *testing.T) {
+	args := []string{"adm", "must-gather", "--dest-dir=/tmp", "--foo"}
+	withRunMock(t, args, "out", nil, func() {
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+			"dest_dir":   "/tmp",
+			"extra_args": []any{"--foo"},
+		}}}
+		res, err := handleMustGather(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.IsError || text(res) != "out" {
+			t.Fatalf("unexpected result: %v", text(res))
+		}
+	})
+}
+
+func TestHandleCrictl(t *testing.T) {
+	args := []string{"debug", "node/n1", "--", "chroot", "/host", "sh", "-c", "crictl ps"}
+	withRunMock(t, args, "ok", nil, func() {
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+			"node_name": "n1",
+		}}}
+		res, err := handleCrictl(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.IsError || text(res) != "ok" {
+			t.Fatalf("unexpected result: %v", text(res))
+		}
+	})
+}
+
+func TestHandleTraverseCgroupfs(t *testing.T) {
+	script := "find /sys/fs/cgroup/kubepods.slice -name memory.current | xargs grep -H ."
+	args := []string{"debug", "node/n1", "--", "chroot", "/host", "sh", "-c", script}
+	withRunMock(t, args, "data", nil, func() {
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+			"node_name": "n1",
+		}}}
+		res, err := handleTraverseCgroupfs(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.IsError || text(res) != "data" {
+			t.Fatalf("unexpected result: %v", text(res))
+		}
+	})
+}
+
+func TestHandleSosReport(t *testing.T) {
+	args := []string{"debug", "node/n1", "--", "chroot", "/host", "toolbox", "--", "sosreport", "-k", "crio.all=on", "-k", "crio.logs=on", "--batch"}
+	withRunMock(t, args, "sos", nil, func() {
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+			"node_name": "n1",
+		}}}
+		res, err := handleSosReport(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.IsError || text(res) != "sos" {
+			t.Fatalf("unexpected result: %v", text(res))
+		}
+	})
+}
+
+func TestHandleNetworkLogs(t *testing.T) {
+	args := []string{"adm", "must-gather", "--", "/usr/bin/gather_network_logs"}
+	withRunMock(t, args, "net", nil, func() {
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{}}}
+		res, err := handleNetworkLogs(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.IsError || text(res) != "net" {
+			t.Fatalf("unexpected result: %v", text(res))
+		}
+	})
+}
+
+func TestHandleProfilingNode(t *testing.T) {
+	args := []string{"adm", "must-gather", "--dest-dir=/tmp", "--", "/usr/bin/gather_profiling_node"}
+	withRunMock(t, args, "prof", nil, func() {
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+			"dest_dir": "/tmp",
+		}}}
+		res, err := handleProfilingNode(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.IsError || text(res) != "prof" {
+			t.Fatalf("unexpected result: %v", text(res))
+		}
+	})
+}
+
+func TestHandleEvents(t *testing.T) {
+	args := []string{"get", "events", "-A"}
+	withRunMock(t, args, "ev", nil, func() {
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{}}}
+		res, err := handleEvents(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.IsError || text(res) != "ev" {
+			t.Fatalf("unexpected result: %v", text(res))
+		}
+	})
+}
+
+func TestHandlePodLogs(t *testing.T) {
+	args := []string{"logs", "-n", "ns", "pod", "-c", "ctr", "--since", "1m"}
+	withRunMock(t, args, "p", nil, func() {
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+			"namespace": "ns",
+			"pod_name":  "pod",
+			"container": "ctr",
+			"since":     "1m",
+		}}}
+		res, err := handlePodLogs(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.IsError || text(res) != "p" {
+			t.Fatalf("unexpected result: %v", text(res))
+		}
+	})
+}
+
+func TestHandleNodeConfig(t *testing.T) {
+	args := []string{"debug", "node/n1", "--", "chroot", "/host", "sh", "-c", "cat /etc/kubernetes/kubelet.conf && echo --- && cat /etc/crio/crio.conf"}
+	withRunMock(t, args, "cfg", nil, func() {
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+			"node_name": "n1",
+		}}}
+		res, err := handleNodeConfig(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.IsError || text(res) != "cfg" {
+			t.Fatalf("unexpected result: %v", text(res))
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- make `openshift` runner variable exported so tests can override it
- add unit tests for new OpenShift helper functions
- add unit tests for each SDK server handler verifying argument parsing

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684d5d80a3d0832fa8e86e230daf68e1