### PR TITLE
Add context-aware oc commands

### DIFF
--- a/pkg/openshift/oc.go
+++ b/pkg/openshift/oc.go
@@ -1,20 +1,21 @@
 package openshift
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
 )
 
 // run executes the oc command with given arguments and returns combined output.
-func run(args ...string) ([]byte, error) {
-	cmd := exec.Command("oc", args...)
+func run(ctx context.Context, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "oc", args...)
 	return cmd.CombinedOutput()
 }
 
 // DebugNode runs `oc debug` for the given node and command.
-func DebugNode(nodeName, command string) (string, error) {
-	out, err := run("debug", fmt.Sprintf("node/%s", nodeName), "--", "chroot", "/host", "sh", "-c", command)
+func DebugNode(ctx context.Context, nodeName, command string) (string, error) {
+	out, err := run(ctx, "debug", fmt.Sprintf("node/%s", nodeName), "--", "chroot", "/host", "sh", "-c", command)
 	if err != nil {
 		return "", fmt.Errorf("oc debug failed: %w: %s", err, out)
 	}
@@ -22,12 +23,12 @@ func DebugNode(nodeName, command string) (string, error) {
 }
 
 // NodeLogs runs `oc adm node-logs` for the given node and since parameter.
-func NodeLogs(nodeName, since string) (string, error) {
+func NodeLogs(ctx context.Context, nodeName, since string) (string, error) {
 	args := []string{"adm", "node-logs", nodeName}
 	if since != "" {
 		args = append(args, "--since", since)
 	}
-	out, err := run(args...)
+	out, err := run(ctx, args...)
 	if err != nil {
 		return "", fmt.Errorf("oc adm node-logs failed: %w: %s", err, out)
 	}
@@ -36,13 +37,13 @@ func NodeLogs(nodeName, since string) (string, error) {
 
 // MustGather runs `oc adm must-gather` with optional destination directory and
 // additional arguments.
-func MustGather(destDir string, extra []string) (string, error) {
+func MustGather(ctx context.Context, destDir string, extra []string) (string, error) {
 	args := []string{"adm", "must-gather"}
 	if destDir != "" {
 		args = append(args, fmt.Sprintf("--dest-dir=%s", destDir))
 	}
 	args = append(args, extra...)
-	out, err := run(args...)
+	out, err := run(ctx, args...)
 	if err != nil {
 		return "", fmt.Errorf("oc adm must-gather failed: %w: %s", err, out)
 	}
@@ -51,12 +52,12 @@ func MustGather(destDir string, extra []string) (string, error) {
 
 // SosReport collects a sosreport from the specified node using toolbox.
 // If caseID is non-empty, it is passed via --case-id.
-func SosReport(nodeName, caseID string) (string, error) {
+func SosReport(ctx context.Context, nodeName, caseID string) (string, error) {
 	args := []string{"debug", fmt.Sprintf("node/%s", nodeName), "--", "chroot", "/host", "toolbox", "--", "sosreport", "-k", "crio.all=on", "-k", "crio.logs=on", "--batch"}
 	if caseID != "" {
 		args = append(args, fmt.Sprintf("--case-id=%s", caseID))
 	}
-	out, err := run(args...)
+	out, err := run(ctx, args...)
 	if err != nil {
 		return "", fmt.Errorf("sosreport failed: %w: %s", err, out)
 	}
@@ -65,20 +66,20 @@ func SosReport(nodeName, caseID string) (string, error) {
 
 // Crictl runs `crictl` inside a debug pod on the specified node with the given arguments.
 // The args slice corresponds to command-line arguments after "crictl".
-func Crictl(nodeName string, args []string) (string, error) {
+func Crictl(ctx context.Context, nodeName string, args []string) (string, error) {
 	cmd := fmt.Sprintf("crictl %s", strings.Join(args, " "))
-	return DebugNode(nodeName, cmd)
+	return DebugNode(ctx, nodeName, cmd)
 }
 
 // NetworkLogs runs the gather_network_logs must-gather addon.
 // It accepts an optional destination directory where the results are written.
-func NetworkLogs(destDir string) (string, error) {
+func NetworkLogs(ctx context.Context, destDir string) (string, error) {
 	args := []string{"adm", "must-gather"}
 	if destDir != "" {
 		args = append(args, fmt.Sprintf("--dest-dir=%s", destDir))
 	}
 	args = append(args, "--", "/usr/bin/gather_network_logs")
-	out, err := run(args...)
+	out, err := run(ctx, args...)
 	if err != nil {
 		return "", fmt.Errorf("gather_network_logs failed: %w: %s", err, out)
 	}
@@ -86,13 +87,13 @@ func NetworkLogs(destDir string) (string, error) {
 }
 
 // ProfilingNode collects pprof dumps from kubelet and CRI-O using gather_profiling_node.
-func ProfilingNode(destDir string) (string, error) {
+func ProfilingNode(ctx context.Context, destDir string) (string, error) {
 	args := []string{"adm", "must-gather"}
 	if destDir != "" {
 		args = append(args, fmt.Sprintf("--dest-dir=%s", destDir))
 	}
 	args = append(args, "--", "/usr/bin/gather_profiling_node")
-	out, err := run(args...)
+	out, err := run(ctx, args...)
 	if err != nil {
 		return "", fmt.Errorf("gather_profiling_node failed: %w: %s", err, out)
 	}
@@ -100,8 +101,8 @@ func ProfilingNode(destDir string) (string, error) {
 }
 
 // Events retrieves recent cluster events across all namespaces.
-func Events() (string, error) {
-	out, err := run("get", "events", "-A")
+func Events(ctx context.Context) (string, error) {
+	out, err := run(ctx, "get", "events", "-A")
 	if err != nil {
 		return "", fmt.Errorf("oc get events failed: %w: %s", err, out)
 	}
@@ -110,7 +111,7 @@ func Events() (string, error) {
 
 // PodLogs fetches logs from a specific pod and container.
 // Namespace and pod name are required. Container and since are optional.
-func PodLogs(namespace, pod, container, since string) (string, error) {
+func PodLogs(ctx context.Context, namespace, pod, container, since string) (string, error) {
 	args := []string{"logs", "-n", namespace, pod}
 	if container != "" {
 		args = append(args, "-c", container)
@@ -118,7 +119,7 @@ func PodLogs(namespace, pod, container, since string) (string, error) {
 	if since != "" {
 		args = append(args, "--since", since)
 	}
-	out, err := run(args...)
+	out, err := run(ctx, args...)
 	if err != nil {
 		return "", fmt.Errorf("oc logs failed: %w: %s", err, out)
 	}
@@ -126,7 +127,7 @@ func PodLogs(namespace, pod, container, since string) (string, error) {
 }
 
 // NodeConfig gathers basic node configuration like kubelet and CRI-O settings.
-func NodeConfig(nodeName string) (string, error) {
+func NodeConfig(ctx context.Context, nodeName string) (string, error) {
 	cmd := "cat /etc/kubernetes/kubelet.conf && echo --- && cat /etc/crio/crio.conf"
-	return DebugNode(nodeName, cmd)
+	return DebugNode(ctx, nodeName, cmd)
 }

--- a/pkg/openshift/oc.go
+++ b/pkg/openshift/oc.go
@@ -8,6 +8,7 @@ import (
 )
 
 // run executes the oc command with given arguments and returns combined output.
+// The provided context governs process lifetime, enabling cancellation and timeouts.
 func run(ctx context.Context, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "oc", args...)
 	return cmd.CombinedOutput()

--- a/pkg/sdkserver/tools.go
+++ b/pkg/sdkserver/tools.go
@@ -132,7 +132,7 @@ func handleDebugNode(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToo
 	}
 	var output bytes.Buffer
 	for _, cmd := range commands {
-		out, err := openshift.DebugNode(nodeName, fmt.Sprint(cmd))
+		out, err := openshift.DebugNode(ctx, nodeName, fmt.Sprint(cmd))
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
@@ -148,7 +148,7 @@ func handleNodeLogs(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallTool
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 	since := req.GetString("since", "")
-	out, err := openshift.NodeLogs(nodeName, since)
+	out, err := openshift.NodeLogs(ctx, nodeName, since)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -181,7 +181,7 @@ func handleMustGather(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallTo
 	for i, a := range extraAny {
 		extras[i] = fmt.Sprint(a)
 	}
-	out, err := openshift.MustGather(dest, extras)
+	out, err := openshift.MustGather(ctx, dest, extras)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -202,7 +202,7 @@ func handleCrictl(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolRe
 	if len(args) == 0 {
 		args = []string{"ps"}
 	}
-	out, err := openshift.Crictl(nodeName, args)
+	out, err := openshift.Crictl(ctx, nodeName, args)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -226,7 +226,7 @@ func handleTraverseCgroupfs(ctx context.Context, req mcp.CallToolRequest) (*mcp.
 		}
 		script = strings.Join(cmds, " && ")
 	}
-	out, err := openshift.DebugNode(nodeName, script)
+	out, err := openshift.DebugNode(ctx, nodeName, script)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -313,7 +313,7 @@ func handleSosReport(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToo
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 	caseID := req.GetString("case_id", "")
-	out, err := openshift.SosReport(nodeName, caseID)
+	out, err := openshift.SosReport(ctx, nodeName, caseID)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -323,7 +323,7 @@ func handleSosReport(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToo
 // handleNetworkLogs runs gather_network_logs via oc adm must-gather.
 func handleNetworkLogs(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dest := req.GetString("dest_dir", "")
-	out, err := openshift.NetworkLogs(dest)
+	out, err := openshift.NetworkLogs(ctx, dest)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -333,7 +333,7 @@ func handleNetworkLogs(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallT
 // handleProfilingNode collects kubelet and CRI-O profiles using gather_profiling_node.
 func handleProfilingNode(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dest := req.GetString("dest_dir", "")
-	out, err := openshift.ProfilingNode(dest)
+	out, err := openshift.ProfilingNode(ctx, dest)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -342,7 +342,7 @@ func handleProfilingNode(ctx context.Context, req mcp.CallToolRequest) (*mcp.Cal
 
 // handleEvents fetches recent cluster events.
 func handleEvents(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	out, err := openshift.Events()
+	out, err := openshift.Events(ctx)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -361,7 +361,7 @@ func handlePodLogs(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolR
 	}
 	container := req.GetString("container", "")
 	since := req.GetString("since", "")
-	out, err := openshift.PodLogs(ns, pod, container, since)
+	out, err := openshift.PodLogs(ctx, ns, pod, container, since)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -374,7 +374,7 @@ func handleNodeConfig(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallTo
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
-	out, err := openshift.NodeConfig(nodeName)
+	out, err := openshift.NodeConfig(ctx, nodeName)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}


### PR DESCRIPTION
## Summary
- propagate context through openshift helpers
- forward context from tool handlers

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684d5d7b8a04832facff0f4f5140f3ea