### PR TITLE
Add file collection support to debug_node

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ Runs `oc debug` on a specified node and executes arbitrary shell commands inside
 Arguments:
 - `node_name` (string, required) – node to debug
 - `commands` (array of string) – commands executed in the pod (defaults to `journalctl --no-pager -u crio`)
-- `collect_files` (bool) – when true, files listed in `paths` are returned as resources
+- `collect_files` (bool) – when true, files listed in `paths` are returned as a tarball resource
 - `paths` (array of string) – file or directory paths to copy from the host
+
+When `collect_files` is enabled, the tool returns a `application/tar+gzip` archive containing the specified paths.
 
 ### `collect_node_logs`
 Streams systemd journal and container runtime logs from a node using `oc adm node-logs`.

--- a/pkg/sdkserver/tools.go
+++ b/pkg/sdkserver/tools.go
@@ -3,6 +3,7 @@ package sdkserver
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -126,6 +127,26 @@ func handleDebugNode(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToo
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
+	if req.GetBool("collect_files", false) {
+		pathsAny, _ := req.GetArguments()["paths"].([]any)
+		if len(pathsAny) > 0 {
+			paths := make([]string, len(pathsAny))
+			for i, p := range pathsAny {
+				paths[i] = fmt.Sprint(p)
+			}
+			data, err := openshift.CopyFilesFromNode(nodeName, paths)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			res := mcp.BlobResourceContents{
+				URI:      "debug-node-files.tar.gz",
+				MIMEType: "application/tar+gzip",
+				Blob:     base64.StdEncoding.EncodeToString(data),
+			}
+			return mcp.NewToolResultResource("collected files", res), nil
+		}
+	}
+
 	commands, _ := req.GetArguments()["commands"].([]any)
 	if len(commands) == 0 {
 		commands = []any{"journalctl --no-pager -u crio"}


### PR DESCRIPTION
## Summary
- add `CopyFilesFromNode` helper wrapping `oc debug` and tar
- allow `debug_node` tool to return a tar.gz archive of requested files
- document the new behavior in README

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684d5d606d50832fa0dbbbca958dedad