### PR TITLE
Add context-aware oc commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require github.com/mark3labs/mcp-go v0.32.0
 
 require (
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/pkg/openshift/oc.go
+++ b/pkg/openshift/oc.go
@@ -1,20 +1,23 @@
 package openshift
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
 )
 
-// run executes the oc command with given arguments and returns combined output.
-func run(args ...string) ([]byte, error) {
-	cmd := exec.Command("oc", args...)
+// Run executes the oc command with given arguments and returns combined output.
+// It is defined as a variable to allow tests to substitute a fake implementation
+// without spawning external processes.
+var Run = func(ctx context.Context, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "oc", args...)
 	return cmd.CombinedOutput()
 }
 
 // DebugNode runs `oc debug` for the given node and command.
-func DebugNode(nodeName, command string) (string, error) {
-	out, err := run("debug", fmt.Sprintf("node/%s", nodeName), "--", "chroot", "/host", "sh", "-c", command)
+func DebugNode(ctx context.Context, nodeName, command string) (string, error) {
+	out, err := Run(ctx, "debug", fmt.Sprintf("node/%s", nodeName), "--", "chroot", "/host", "sh", "-c", command)
 	if err != nil {
 		return "", fmt.Errorf("oc debug failed: %w: %s", err, out)
 	}
@@ -22,27 +25,26 @@ func DebugNode(nodeName, command string) (string, error) {
 }
 
 // NodeLogs runs `oc adm node-logs` for the given node and since parameter.
-func NodeLogs(nodeName, since string) (string, error) {
+func NodeLogs(ctx context.Context, nodeName, since string) (string, error) {
 	args := []string{"adm", "node-logs", nodeName}
 	if since != "" {
 		args = append(args, "--since", since)
 	}
-	out, err := run(args...)
+	out, err := Run(ctx, args...)
 	if err != nil {
 		return "", fmt.Errorf("oc adm node-logs failed: %w: %s", err, out)
 	}
 	return string(out), nil
 }
 
-// MustGather runs `oc adm must-gather` with optional destination directory and
-// additional arguments.
-func MustGather(destDir string, extra []string) (string, error) {
+// MustGather runs `oc adm must-gather` with optional destination directory and additional arguments.
+func MustGather(ctx context.Context, destDir string, extra []string) (string, error) {
 	args := []string{"adm", "must-gather"}
 	if destDir != "" {
 		args = append(args, fmt.Sprintf("--dest-dir=%s", destDir))
 	}
 	args = append(args, extra...)
-	out, err := run(args...)
+	out, err := Run(ctx, args...)
 	if err != nil {
 		return "", fmt.Errorf("oc adm must-gather failed: %w: %s", err, out)
 	}
@@ -51,12 +53,12 @@ func MustGather(destDir string, extra []string) (string, error) {
 
 // SosReport collects a sosreport from the specified node using toolbox.
 // If caseID is non-empty, it is passed via --case-id.
-func SosReport(nodeName, caseID string) (string, error) {
+func SosReport(ctx context.Context, nodeName, caseID string) (string, error) {
 	args := []string{"debug", fmt.Sprintf("node/%s", nodeName), "--", "chroot", "/host", "toolbox", "--", "sosreport", "-k", "crio.all=on", "-k", "crio.logs=on", "--batch"}
 	if caseID != "" {
 		args = append(args, fmt.Sprintf("--case-id=%s", caseID))
 	}
-	out, err := run(args...)
+	out, err := Run(ctx, args...)
 	if err != nil {
 		return "", fmt.Errorf("sosreport failed: %w: %s", err, out)
 	}
@@ -65,20 +67,20 @@ func SosReport(nodeName, caseID string) (string, error) {
 
 // Crictl runs `crictl` inside a debug pod on the specified node with the given arguments.
 // The args slice corresponds to command-line arguments after "crictl".
-func Crictl(nodeName string, args []string) (string, error) {
+func Crictl(ctx context.Context, nodeName string, args []string) (string, error) {
 	cmd := fmt.Sprintf("crictl %s", strings.Join(args, " "))
-	return DebugNode(nodeName, cmd)
+	return DebugNode(ctx, nodeName, cmd)
 }
 
 // NetworkLogs runs the gather_network_logs must-gather addon.
 // It accepts an optional destination directory where the results are written.
-func NetworkLogs(destDir string) (string, error) {
+func NetworkLogs(ctx context.Context, destDir string) (string, error) {
 	args := []string{"adm", "must-gather"}
 	if destDir != "" {
 		args = append(args, fmt.Sprintf("--dest-dir=%s", destDir))
 	}
 	args = append(args, "--", "/usr/bin/gather_network_logs")
-	out, err := run(args...)
+	out, err := Run(ctx, args...)
 	if err != nil {
 		return "", fmt.Errorf("gather_network_logs failed: %w: %s", err, out)
 	}
@@ -86,13 +88,13 @@ func NetworkLogs(destDir string) (string, error) {
 }
 
 // ProfilingNode collects pprof dumps from kubelet and CRI-O using gather_profiling_node.
-func ProfilingNode(destDir string) (string, error) {
+func ProfilingNode(ctx context.Context, destDir string) (string, error) {
 	args := []string{"adm", "must-gather"}
 	if destDir != "" {
 		args = append(args, fmt.Sprintf("--dest-dir=%s", destDir))
 	}
 	args = append(args, "--", "/usr/bin/gather_profiling_node")
-	out, err := run(args...)
+	out, err := Run(ctx, args...)
 	if err != nil {
 		return "", fmt.Errorf("gather_profiling_node failed: %w: %s", err, out)
 	}
@@ -100,8 +102,8 @@ func ProfilingNode(destDir string) (string, error) {
 }
 
 // Events retrieves recent cluster events across all namespaces.
-func Events() (string, error) {
-	out, err := run("get", "events", "-A")
+func Events(ctx context.Context) (string, error) {
+	out, err := Run(ctx, "get", "events", "-A")
 	if err != nil {
 		return "", fmt.Errorf("oc get events failed: %w: %s", err, out)
 	}
@@ -110,7 +112,7 @@ func Events() (string, error) {
 
 // PodLogs fetches logs from a specific pod and container.
 // Namespace and pod name are required. Container and since are optional.
-func PodLogs(namespace, pod, container, since string) (string, error) {
+func PodLogs(ctx context.Context, namespace, pod, container, since string) (string, error) {
 	args := []string{"logs", "-n", namespace, pod}
 	if container != "" {
 		args = append(args, "-c", container)
@@ -118,7 +120,7 @@ func PodLogs(namespace, pod, container, since string) (string, error) {
 	if since != "" {
 		args = append(args, "--since", since)
 	}
-	out, err := run(args...)
+	out, err := Run(ctx, args...)
 	if err != nil {
 		return "", fmt.Errorf("oc logs failed: %w: %s", err, out)
 	}
@@ -126,7 +128,7 @@ func PodLogs(namespace, pod, container, since string) (string, error) {
 }
 
 // NodeConfig gathers basic node configuration like kubelet and CRI-O settings.
-func NodeConfig(nodeName string) (string, error) {
+func NodeConfig(ctx context.Context, nodeName string) (string, error) {
 	cmd := "cat /etc/kubernetes/kubelet.conf && echo --- && cat /etc/crio/crio.conf"
-	return DebugNode(nodeName, cmd)
+	return DebugNode(ctx, nodeName, cmd)
 }

--- a/pkg/openshift/oc_test.go
+++ b/pkg/openshift/oc_test.go
@@ -1,0 +1,120 @@
+package openshift
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// helper to replace run during tests
+func withRunMock(f func(ctx context.Context, args ...string) ([]byte, error), test func()) {
+	orig := Run
+	Run = f
+	defer func() { Run = orig }()
+	test()
+}
+
+func TestNetworkLogs(t *testing.T) {
+	expected := []string{"adm", "must-gather", "--dest-dir=test", "--", "/usr/bin/gather_network_logs"}
+	withRunMock(func(ctx context.Context, args ...string) ([]byte, error) {
+		if fmt.Sprint(args) != fmt.Sprint(expected) {
+			t.Fatalf("unexpected args %v", args)
+		}
+		return []byte("logs"), nil
+	}, func() {
+		out, err := NetworkLogs(context.Background(), "test")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out != "logs" {
+			t.Fatalf("unexpected output %q", out)
+		}
+	})
+}
+
+func TestNetworkLogsError(t *testing.T) {
+	withRunMock(func(ctx context.Context, args ...string) ([]byte, error) {
+		return []byte("bad"), errors.New("failure")
+	}, func() {
+		out, err := NetworkLogs(context.Background(), "")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if out != "" {
+			t.Fatalf("expected empty output, got %q", out)
+		}
+	})
+}
+
+func TestProfilingNode(t *testing.T) {
+	expected := []string{"adm", "must-gather", "--dest-dir=/tmp", "--", "/usr/bin/gather_profiling_node"}
+	withRunMock(func(ctx context.Context, args ...string) ([]byte, error) {
+		if fmt.Sprint(args) != fmt.Sprint(expected) {
+			t.Fatalf("unexpected args %v", args)
+		}
+		return []byte("prof"), nil
+	}, func() {
+		out, err := ProfilingNode(context.Background(), "/tmp")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out != "prof" {
+			t.Fatalf("unexpected output %q", out)
+		}
+	})
+}
+
+func TestEvents(t *testing.T) {
+	expected := []string{"get", "events", "-A"}
+	withRunMock(func(ctx context.Context, args ...string) ([]byte, error) {
+		if fmt.Sprint(args) != fmt.Sprint(expected) {
+			t.Fatalf("unexpected args %v", args)
+		}
+		return []byte("events"), nil
+	}, func() {
+		out, err := Events(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out != "events" {
+			t.Fatalf("unexpected output %q", out)
+		}
+	})
+}
+
+func TestPodLogs(t *testing.T) {
+	expected := []string{"logs", "-n", "ns", "pod", "-c", "ctr", "--since", "2h"}
+	withRunMock(func(ctx context.Context, args ...string) ([]byte, error) {
+		if fmt.Sprint(args) != fmt.Sprint(expected) {
+			t.Fatalf("unexpected args %v", args)
+		}
+		return []byte("pod logs"), nil
+	}, func() {
+		out, err := PodLogs(context.Background(), "ns", "pod", "ctr", "2h")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out != "pod logs" {
+			t.Fatalf("unexpected output %q", out)
+		}
+	})
+}
+
+func TestNodeConfig(t *testing.T) {
+	expected := []string{"debug", "node/testnode", "--", "chroot", "/host", "sh", "-c", "cat /etc/kubernetes/kubelet.conf && echo --- && cat /etc/crio/crio.conf"}
+	withRunMock(func(ctx context.Context, args ...string) ([]byte, error) {
+		if fmt.Sprint(args) != fmt.Sprint(expected) {
+			t.Fatalf("unexpected args %v", args)
+		}
+		return []byte("cfg"), nil
+	}, func() {
+		out, err := NodeConfig(context.Background(), "testnode")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out != "cfg" {
+			t.Fatalf("unexpected output %q", out)
+		}
+	})
+}

--- a/pkg/sdkserver/tools.go
+++ b/pkg/sdkserver/tools.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/harche/crio-mcp-server/pkg/openshift"
 	mcp "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 )
 
 // debugNodeTool defines the debug_node MCP tool.
@@ -132,7 +133,7 @@ func handleDebugNode(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToo
 	}
 	var output bytes.Buffer
 	for _, cmd := range commands {
-		out, err := openshift.DebugNode(nodeName, fmt.Sprint(cmd))
+		out, err := openshift.DebugNode(ctx, nodeName, fmt.Sprint(cmd))
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
@@ -148,7 +149,7 @@ func handleNodeLogs(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallTool
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 	since := req.GetString("since", "")
-	out, err := openshift.NodeLogs(nodeName, since)
+	out, err := openshift.NodeLogs(ctx, nodeName, since)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -181,7 +182,7 @@ func handleMustGather(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallTo
 	for i, a := range extraAny {
 		extras[i] = fmt.Sprint(a)
 	}
-	out, err := openshift.MustGather(dest, extras)
+	out, err := openshift.MustGather(ctx, dest, extras)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -202,7 +203,7 @@ func handleCrictl(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolRe
 	if len(args) == 0 {
 		args = []string{"ps"}
 	}
-	out, err := openshift.Crictl(nodeName, args)
+	out, err := openshift.Crictl(ctx, nodeName, args)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -226,7 +227,7 @@ func handleTraverseCgroupfs(ctx context.Context, req mcp.CallToolRequest) (*mcp.
 		}
 		script = strings.Join(cmds, " && ")
 	}
-	out, err := openshift.DebugNode(nodeName, script)
+	out, err := openshift.DebugNode(ctx, nodeName, script)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -313,7 +314,7 @@ func handleSosReport(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToo
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 	caseID := req.GetString("case_id", "")
-	out, err := openshift.SosReport(nodeName, caseID)
+	out, err := openshift.SosReport(ctx, nodeName, caseID)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -323,7 +324,7 @@ func handleSosReport(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToo
 // handleNetworkLogs runs gather_network_logs via oc adm must-gather.
 func handleNetworkLogs(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dest := req.GetString("dest_dir", "")
-	out, err := openshift.NetworkLogs(dest)
+	out, err := openshift.NetworkLogs(ctx, dest)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -333,7 +334,7 @@ func handleNetworkLogs(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallT
 // handleProfilingNode collects kubelet and CRI-O profiles using gather_profiling_node.
 func handleProfilingNode(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dest := req.GetString("dest_dir", "")
-	out, err := openshift.ProfilingNode(dest)
+	out, err := openshift.ProfilingNode(ctx, dest)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -342,7 +343,7 @@ func handleProfilingNode(ctx context.Context, req mcp.CallToolRequest) (*mcp.Cal
 
 // handleEvents fetches recent cluster events.
 func handleEvents(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	out, err := openshift.Events()
+	out, err := openshift.Events(ctx)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -361,7 +362,7 @@ func handlePodLogs(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolR
 	}
 	container := req.GetString("container", "")
 	since := req.GetString("since", "")
-	out, err := openshift.PodLogs(ns, pod, container, since)
+	out, err := openshift.PodLogs(ctx, ns, pod, container, since)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -374,9 +375,27 @@ func handleNodeConfig(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallTo
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
-	out, err := openshift.NodeConfig(nodeName)
+	out, err := openshift.NodeConfig(ctx, nodeName)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 	return mcp.NewToolResultText(out), nil
+}
+
+// RegisterTools registers all available tools with the provided server.
+func RegisterTools(s *server.MCPServer) {
+	s.AddTools(
+		server.ServerTool{Tool: debugNodeTool, Handler: handleDebugNode},
+		server.ServerTool{Tool: nodeLogsTool, Handler: handleNodeLogs},
+		server.ServerTool{Tool: pprofTool, Handler: handlePprof},
+		server.ServerTool{Tool: mustGatherTool, Handler: handleMustGather},
+		server.ServerTool{Tool: crictlTool, Handler: handleCrictl},
+		server.ServerTool{Tool: cgroupfsTool, Handler: handleTraverseCgroupfs},
+		server.ServerTool{Tool: sosReportTool, Handler: handleSosReport},
+		server.ServerTool{Tool: networkLogsTool, Handler: handleNetworkLogs},
+		server.ServerTool{Tool: profilingTool, Handler: handleProfilingNode},
+		server.ServerTool{Tool: eventsTool, Handler: handleEvents},
+		server.ServerTool{Tool: podLogsTool, Handler: handlePodLogs},
+		server.ServerTool{Tool: nodeConfigTool, Handler: handleNodeConfig},
+	)
 }

--- a/pkg/sdkserver/tools_test.go
+++ b/pkg/sdkserver/tools_test.go
@@ -1,0 +1,249 @@
+package sdkserver
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/harche/crio-mcp-server/pkg/openshift"
+	mcp "github.com/mark3labs/mcp-go/mcp"
+)
+
+func withRunMock(t *testing.T, expected []string, output string, err error, f func()) {
+	orig := openshift.Run
+	openshift.Run = func(ctx context.Context, args ...string) ([]byte, error) {
+		if fmt.Sprint(args) != fmt.Sprint(expected) {
+			t.Fatalf("unexpected args %v", args)
+		}
+		return []byte(output), err
+	}
+	defer func() { openshift.Run = orig }()
+	f()
+}
+
+func text(result *mcp.CallToolResult) string {
+	if len(result.Content) == 0 {
+		return ""
+	}
+	return result.Content[0].(mcp.TextContent).Text
+}
+
+func TestHandleDebugNode(t *testing.T) {
+	expectedArgs := []string{"debug", "node/test", "--", "chroot", "/host", "sh", "-c", "echo hi"}
+	withRunMock(t, expectedArgs, "hi", nil, func() {
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+			"node_name": "test",
+			"commands":  []any{"echo hi"},
+		}}}
+		res, err := handleDebugNode(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.IsError {
+			t.Fatalf("unexpected error result: %v", text(res))
+		}
+		if text(res) != "hi" {
+			t.Fatalf("unexpected result %q", text(res))
+		}
+	})
+}
+
+func TestHandleDebugNodeMissingArg(t *testing.T) {
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{}}}
+	res, err := handleDebugNode(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected error result")
+	}
+}
+
+func TestHandleNodeLogs(t *testing.T) {
+	args := []string{"adm", "node-logs", "node1", "--since", "1h"}
+	withRunMock(t, args, "logs", nil, func() {
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+			"node_name": "node1",
+			"since":     "1h",
+		}}}
+		res, err := handleNodeLogs(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.IsError || text(res) != "logs" {
+			t.Fatalf("unexpected result: %v", text(res))
+		}
+	})
+}
+
+func TestHandlePprofArgsRequired(t *testing.T) {
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{}}}
+	res, err := handlePprof(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected error result")
+	}
+}
+
+func TestHandlePprof(t *testing.T) {
+	req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"args": []any{"-h"},
+	}}}
+	res, err := handlePprof(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error result: %v", text(res))
+	}
+	if text(res) == "" {
+		t.Fatalf("expected output")
+	}
+}
+
+func TestHandleMustGather(t *testing.T) {
+	args := []string{"adm", "must-gather", "--dest-dir=/tmp", "--foo"}
+	withRunMock(t, args, "out", nil, func() {
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+			"dest_dir":   "/tmp",
+			"extra_args": []any{"--foo"},
+		}}}
+		res, err := handleMustGather(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.IsError || text(res) != "out" {
+			t.Fatalf("unexpected result: %v", text(res))
+		}
+	})
+}
+
+func TestHandleCrictl(t *testing.T) {
+	args := []string{"debug", "node/n1", "--", "chroot", "/host", "sh", "-c", "crictl ps"}
+	withRunMock(t, args, "ok", nil, func() {
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+			"node_name": "n1",
+		}}}
+		res, err := handleCrictl(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.IsError || text(res) != "ok" {
+			t.Fatalf("unexpected result: %v", text(res))
+		}
+	})
+}
+
+func TestHandleTraverseCgroupfs(t *testing.T) {
+	script := "find /sys/fs/cgroup/kubepods.slice -name memory.current | xargs grep -H ."
+	args := []string{"debug", "node/n1", "--", "chroot", "/host", "sh", "-c", script}
+	withRunMock(t, args, "data", nil, func() {
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+			"node_name": "n1",
+		}}}
+		res, err := handleTraverseCgroupfs(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.IsError || text(res) != "data" {
+			t.Fatalf("unexpected result: %v", text(res))
+		}
+	})
+}
+
+func TestHandleSosReport(t *testing.T) {
+	args := []string{"debug", "node/n1", "--", "chroot", "/host", "toolbox", "--", "sosreport", "-k", "crio.all=on", "-k", "crio.logs=on", "--batch"}
+	withRunMock(t, args, "sos", nil, func() {
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+			"node_name": "n1",
+		}}}
+		res, err := handleSosReport(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.IsError || text(res) != "sos" {
+			t.Fatalf("unexpected result: %v", text(res))
+		}
+	})
+}
+
+func TestHandleNetworkLogs(t *testing.T) {
+	args := []string{"adm", "must-gather", "--", "/usr/bin/gather_network_logs"}
+	withRunMock(t, args, "net", nil, func() {
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{}}}
+		res, err := handleNetworkLogs(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.IsError || text(res) != "net" {
+			t.Fatalf("unexpected result: %v", text(res))
+		}
+	})
+}
+
+func TestHandleProfilingNode(t *testing.T) {
+	args := []string{"adm", "must-gather", "--dest-dir=/tmp", "--", "/usr/bin/gather_profiling_node"}
+	withRunMock(t, args, "prof", nil, func() {
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+			"dest_dir": "/tmp",
+		}}}
+		res, err := handleProfilingNode(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.IsError || text(res) != "prof" {
+			t.Fatalf("unexpected result: %v", text(res))
+		}
+	})
+}
+
+func TestHandleEvents(t *testing.T) {
+	args := []string{"get", "events", "-A"}
+	withRunMock(t, args, "ev", nil, func() {
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{}}}
+		res, err := handleEvents(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.IsError || text(res) != "ev" {
+			t.Fatalf("unexpected result: %v", text(res))
+		}
+	})
+}
+
+func TestHandlePodLogs(t *testing.T) {
+	args := []string{"logs", "-n", "ns", "pod", "-c", "ctr", "--since", "1m"}
+	withRunMock(t, args, "p", nil, func() {
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+			"namespace": "ns",
+			"pod_name":  "pod",
+			"container": "ctr",
+			"since":     "1m",
+		}}}
+		res, err := handlePodLogs(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.IsError || text(res) != "p" {
+			t.Fatalf("unexpected result: %v", text(res))
+		}
+	})
+}
+
+func TestHandleNodeConfig(t *testing.T) {
+	args := []string{"debug", "node/n1", "--", "chroot", "/host", "sh", "-c", "cat /etc/kubernetes/kubelet.conf && echo --- && cat /etc/crio/crio.conf"}
+	withRunMock(t, args, "cfg", nil, func() {
+		req := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+			"node_name": "n1",
+		}}}
+		res, err := handleNodeConfig(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.IsError || text(res) != "cfg" {
+			t.Fatalf("unexpected result: %v", text(res))
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- propagate context through openshift helpers
- forward context from tool handlers
- update tests for context-aware runner

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684d5d7b8a04832facff0f4f5140f3ea