### PR TITLE
Add Red Hat KB and CVE tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,17 @@ Uses `oc debug` to print kubelet and CRI-O configuration files from the node.
 Arguments:
 - `node_name` (string, required) – node to inspect
 
+### `search_kcs`
+Queries the Red Hat Knowledge Base using the Case Management API.
+
+Arguments:
+- `query` (string, required) – search keywords
+- `rows` (number) – number of results to return (default 20)
+- `offline_token` (string, required) – offline access token for authentication
+
+### `get_cve`
+Retrieves CVE details from the Red Hat Security Data API.
+
+Arguments:
+- `cve_id` (string, required) – identifier like `CVE-2025-1234`
+

--- a/pkg/redhat/redhat.go
+++ b/pkg/redhat/redhat.go
@@ -1,0 +1,99 @@
+package redhat
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+var Do = http.DefaultClient.Do
+
+// AccessToken exchanges an offline token for a short-lived access token.
+func AccessToken(offlineToken string) (string, error) {
+	data := url.Values{}
+	data.Set("grant_type", "refresh_token")
+	data.Set("client_id", "rhsm-api")
+	data.Set("refresh_token", offlineToken)
+	req, err := http.NewRequest("POST", "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token", strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token request failed: %s", resp.Status)
+	}
+	var result struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", err
+	}
+	if result.AccessToken == "" {
+		return "", fmt.Errorf("access_token not found")
+	}
+	return result.AccessToken, nil
+}
+
+// SearchKCS queries the Red Hat Knowledge Base for articles matching the query.
+func SearchKCS(query string, rows int, offlineToken string) (string, error) {
+	token, err := AccessToken(offlineToken)
+	if err != nil {
+		return "", err
+	}
+	if rows <= 0 {
+		rows = 20
+	}
+	endpoint := "https://access.redhat.com/hydra/rest/search/kcs?format=json&q=" + url.QueryEscape(query) + "&rows=" + fmt.Sprint(rows)
+	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("search request failed: %s", resp.Status)
+	}
+	return string(body), nil
+}
+
+// CVEInfo fetches details for a given CVE ID using the Security Data API.
+func CVEInfo(cveID string) (string, error) {
+	endpoint := "https://access.redhat.com/hydra/rest/securitydata/cve/" + url.QueryEscape(cveID) + ".json"
+	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("cve request failed: %s", resp.Status)
+	}
+	return string(body), nil
+}

--- a/pkg/redhat/redhat_test.go
+++ b/pkg/redhat/redhat_test.go
@@ -1,0 +1,64 @@
+package redhat
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func withDoMock(f func(req *http.Request) (*http.Response, error), test func()) {
+	orig := Do
+	Do = f
+	defer func() { Do = orig }()
+	test()
+}
+
+func TestSearchKCS(t *testing.T) {
+	calls := 0
+	withDoMock(func(req *http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			if req.URL.Host != "sso.redhat.com" {
+				t.Fatalf("unexpected host %s", req.URL.Host)
+			}
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"access_token":"tok"}`))}, nil
+		}
+		if calls == 2 {
+			if !strings.Contains(req.URL.Path, "/search/kcs") {
+				t.Fatalf("unexpected path %s", req.URL.Path)
+			}
+			if req.Header.Get("Authorization") != "Bearer tok" {
+				t.Fatalf("missing auth header")
+			}
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("result"))}, nil
+		}
+		return nil, fmt.Errorf("extra call")
+	}, func() {
+		out, err := SearchKCS("bug", 10, "off")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out != "result" {
+			t.Fatalf("unexpected output %q", out)
+		}
+	})
+}
+
+func TestCVEInfo(t *testing.T) {
+	withDoMock(func(req *http.Request) (*http.Response, error) {
+		if !strings.Contains(req.URL.Path, "/CVE-1234.json") {
+			t.Fatalf("unexpected path %s", req.URL.Path)
+		}
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("cve"))}, nil
+	}, func() {
+		out, err := CVEInfo("CVE-1234")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out != "cve" {
+			t.Fatalf("unexpected output %q", out)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- implement a small Red Hat API client
- add `search_kcs` and `get_cve` tools
- document the new tools
- test new handlers and API helpers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684d70dfe924832f901f7f9c0990a3c5