### PR TITLE
Add context parameter to oc commands

### DIFF
--- a/pkg/openshift/oc_test.go
+++ b/pkg/openshift/oc_test.go
@@ -1,13 +1,14 @@
 package openshift
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
 )
 
 // helper to replace run during tests
-func withRunMock(f func(args ...string) ([]byte, error), test func()) {
+func withRunMock(f func(ctx context.Context, args ...string) ([]byte, error), test func()) {
 	orig := Run
 	Run = f
 	defer func() { Run = orig }()
@@ -16,13 +17,13 @@ func withRunMock(f func(args ...string) ([]byte, error), test func()) {
 
 func TestNetworkLogs(t *testing.T) {
 	expected := []string{"adm", "must-gather", "--dest-dir=test", "--", "/usr/bin/gather_network_logs"}
-	withRunMock(func(args ...string) ([]byte, error) {
+	withRunMock(func(ctx context.Context, args ...string) ([]byte, error) {
 		if fmt.Sprint(args) != fmt.Sprint(expected) {
 			t.Fatalf("unexpected args %v", args)
 		}
 		return []byte("logs"), nil
 	}, func() {
-		out, err := NetworkLogs("test")
+		out, err := NetworkLogs(context.Background(), "test")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -33,10 +34,10 @@ func TestNetworkLogs(t *testing.T) {
 }
 
 func TestNetworkLogsError(t *testing.T) {
-	withRunMock(func(args ...string) ([]byte, error) {
+	withRunMock(func(ctx context.Context, args ...string) ([]byte, error) {
 		return []byte("bad"), errors.New("failure")
 	}, func() {
-		out, err := NetworkLogs("")
+		out, err := NetworkLogs(context.Background(), "")
 		if err == nil {
 			t.Fatal("expected error")
 		}
@@ -48,13 +49,13 @@ func TestNetworkLogsError(t *testing.T) {
 
 func TestProfilingNode(t *testing.T) {
 	expected := []string{"adm", "must-gather", "--dest-dir=/tmp", "--", "/usr/bin/gather_profiling_node"}
-	withRunMock(func(args ...string) ([]byte, error) {
+	withRunMock(func(ctx context.Context, args ...string) ([]byte, error) {
 		if fmt.Sprint(args) != fmt.Sprint(expected) {
 			t.Fatalf("unexpected args %v", args)
 		}
 		return []byte("prof"), nil
 	}, func() {
-		out, err := ProfilingNode("/tmp")
+		out, err := ProfilingNode(context.Background(), "/tmp")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -66,13 +67,13 @@ func TestProfilingNode(t *testing.T) {
 
 func TestEvents(t *testing.T) {
 	expected := []string{"get", "events", "-A"}
-	withRunMock(func(args ...string) ([]byte, error) {
+	withRunMock(func(ctx context.Context, args ...string) ([]byte, error) {
 		if fmt.Sprint(args) != fmt.Sprint(expected) {
 			t.Fatalf("unexpected args %v", args)
 		}
 		return []byte("events"), nil
 	}, func() {
-		out, err := Events()
+		out, err := Events(context.Background())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -84,13 +85,13 @@ func TestEvents(t *testing.T) {
 
 func TestPodLogs(t *testing.T) {
 	expected := []string{"logs", "-n", "ns", "pod", "-c", "ctr", "--since", "2h"}
-	withRunMock(func(args ...string) ([]byte, error) {
+	withRunMock(func(ctx context.Context, args ...string) ([]byte, error) {
 		if fmt.Sprint(args) != fmt.Sprint(expected) {
 			t.Fatalf("unexpected args %v", args)
 		}
 		return []byte("pod logs"), nil
 	}, func() {
-		out, err := PodLogs("ns", "pod", "ctr", "2h")
+		out, err := PodLogs(context.Background(), "ns", "pod", "ctr", "2h")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -102,13 +103,13 @@ func TestPodLogs(t *testing.T) {
 
 func TestNodeConfig(t *testing.T) {
 	expected := []string{"debug", "node/testnode", "--", "chroot", "/host", "sh", "-c", "cat /etc/kubernetes/kubelet.conf && echo --- && cat /etc/crio/crio.conf"}
-	withRunMock(func(args ...string) ([]byte, error) {
+	withRunMock(func(ctx context.Context, args ...string) ([]byte, error) {
 		if fmt.Sprint(args) != fmt.Sprint(expected) {
 			t.Fatalf("unexpected args %v", args)
 		}
 		return []byte("cfg"), nil
 	}, func() {
-		out, err := NodeConfig("testnode")
+		out, err := NodeConfig(context.Background(), "testnode")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -120,13 +121,13 @@ func TestNodeConfig(t *testing.T) {
 
 func TestNodeMetrics(t *testing.T) {
 	expected := []string{"adm", "top", "nodes"}
-	withRunMock(func(args ...string) ([]byte, error) {
+	withRunMock(func(ctx context.Context, args ...string) ([]byte, error) {
 		if fmt.Sprint(args) != fmt.Sprint(expected) {
 			t.Fatalf("unexpected args %v", args)
 		}
 		return []byte("metrics"), nil
 	}, func() {
-		out, err := NodeMetrics()
+		out, err := NodeMetrics(context.Background())
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -138,13 +139,13 @@ func TestNodeMetrics(t *testing.T) {
 
 func TestPrometheusQuery(t *testing.T) {
 	expected := []string{"get", "--raw", "/api/v1/namespaces/openshift-monitoring/services/prometheus-k8s:9091/proxy/api/v1/query?query=up"}
-	withRunMock(func(args ...string) ([]byte, error) {
+	withRunMock(func(ctx context.Context, args ...string) ([]byte, error) {
 		if fmt.Sprint(args) != fmt.Sprint(expected) {
 			t.Fatalf("unexpected args %v", args)
 		}
 		return []byte("{\"status\":\"success\"}"), nil
 	}, func() {
-		out, err := PrometheusQuery("up")
+		out, err := PrometheusQuery(context.Background(), "up")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/pkg/sdkserver/tools.go
+++ b/pkg/sdkserver/tools.go
@@ -137,7 +137,7 @@ func handleDebugNode(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToo
 			for i, p := range pathsAny {
 				paths[i] = fmt.Sprint(p)
 			}
-			data, err := openshift.CopyFilesFromNode(nodeName, paths)
+			data, err := openshift.CopyFilesFromNode(ctx, nodeName, paths)
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
@@ -156,7 +156,7 @@ func handleDebugNode(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToo
 	}
 	var output bytes.Buffer
 	for _, cmd := range commands {
-		out, err := openshift.DebugNode(nodeName, fmt.Sprint(cmd))
+		out, err := openshift.DebugNode(ctx, nodeName, fmt.Sprint(cmd))
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
@@ -173,7 +173,7 @@ func handleNodeLogs(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallTool
 	}
 	since := req.GetString("since", "")
 	compressLogs := req.GetBool("compress", false)
-	out, err := openshift.NodeLogs(nodeName, since)
+	out, err := openshift.NodeLogs(ctx, nodeName, since)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -226,7 +226,7 @@ func handleMustGather(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallTo
 	for i, a := range extraAny {
 		extras[i] = fmt.Sprint(a)
 	}
-	out, err := openshift.MustGather(dest, extras)
+	out, err := openshift.MustGather(ctx, dest, extras)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -247,7 +247,7 @@ func handleCrictl(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolRe
 	if len(args) == 0 {
 		args = []string{"ps"}
 	}
-	out, err := openshift.Crictl(nodeName, args)
+	out, err := openshift.Crictl(ctx, nodeName, args)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -271,7 +271,7 @@ func handleTraverseCgroupfs(ctx context.Context, req mcp.CallToolRequest) (*mcp.
 		}
 		script = strings.Join(cmds, " && ")
 	}
-	out, err := openshift.DebugNode(nodeName, script)
+	out, err := openshift.DebugNode(ctx, nodeName, script)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -406,7 +406,7 @@ func handleSosReport(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToo
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 	caseID := req.GetString("case_id", "")
-	out, err := openshift.SosReport(nodeName, caseID)
+	out, err := openshift.SosReport(ctx, nodeName, caseID)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -416,7 +416,7 @@ func handleSosReport(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToo
 // handleNetworkLogs runs gather_network_logs via oc adm must-gather.
 func handleNetworkLogs(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dest := req.GetString("dest_dir", "")
-	out, err := openshift.NetworkLogs(dest)
+	out, err := openshift.NetworkLogs(ctx, dest)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -426,7 +426,7 @@ func handleNetworkLogs(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallT
 // handleProfilingNode collects kubelet and CRI-O profiles using gather_profiling_node.
 func handleProfilingNode(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	dest := req.GetString("dest_dir", "")
-	out, err := openshift.ProfilingNode(dest)
+	out, err := openshift.ProfilingNode(ctx, dest)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -435,7 +435,7 @@ func handleProfilingNode(ctx context.Context, req mcp.CallToolRequest) (*mcp.Cal
 
 // handleEvents fetches recent cluster events.
 func handleEvents(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	out, err := openshift.Events()
+	out, err := openshift.Events(ctx)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -444,7 +444,7 @@ func handleEvents(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolRe
 
 // handleNodeMetrics retrieves metrics for all nodes.
 func handleNodeMetrics(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	out, err := openshift.NodeMetrics()
+	out, err := openshift.NodeMetrics(ctx)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -457,7 +457,7 @@ func handlePrometheusQuery(ctx context.Context, req mcp.CallToolRequest) (*mcp.C
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
-	out, err := openshift.PrometheusQuery(q)
+	out, err := openshift.PrometheusQuery(ctx, q)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -476,7 +476,7 @@ func handlePodLogs(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolR
 	}
 	container := req.GetString("container", "")
 	since := req.GetString("since", "")
-	out, err := openshift.PodLogs(ns, pod, container, since)
+	out, err := openshift.PodLogs(ctx, ns, pod, container, since)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -489,7 +489,7 @@ func handleNodeConfig(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallTo
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
-	out, err := openshift.NodeConfig(nodeName)
+	out, err := openshift.NodeConfig(ctx, nodeName)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}

--- a/pkg/sdkserver/tools_test.go
+++ b/pkg/sdkserver/tools_test.go
@@ -15,7 +15,7 @@ import (
 
 func withRunMock(t *testing.T, expected []string, output string, err error, f func()) {
 	orig := openshift.Run
-	openshift.Run = func(args ...string) ([]byte, error) {
+	openshift.Run = func(ctx context.Context, args ...string) ([]byte, error) {
 		if fmt.Sprint(args) != fmt.Sprint(expected) {
 			t.Fatalf("unexpected args %v", args)
 		}


### PR DESCRIPTION
## Summary
- use `exec.CommandContext` for `Run`
- thread `context.Context` through `pkg/openshift` helpers
- update sdk handlers to pass context
- adjust tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684d951d403c832f94177a395d582450